### PR TITLE
fix: s3-sync github action job부분 브랜치 네임 수정

### DIFF
--- a/.github/workflows/aws-s3-deploy.yml
+++ b/.github/workflows/aws-s3-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: deploy to s3
-        uses: jakejarvis/s3-sync-action@main
+        uses: jakejarvis/s3-sync-action@master
         with:
           args: --delete
         env:


### PR DESCRIPTION
jakejarvis/s3-sync-action@main job부분에서 action을 담고 있는 브랜치가 main이 아니고 master라서 수정하였습니다